### PR TITLE
feat(cfg): add gitFilePathPattern per cluster with placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ site
 
 # vscode database functionality support files
 *.session.sql
+.vscode
 
 # E2E test reports
 e2e-test-report/

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -60,11 +60,13 @@ kubernetes:
       upbound: {}
   clusterLocatorMethods:
   - clusters:
-    - authMetadata:
+    - name: solution-idp-non-prod-frontend-frontend
+      authMetadata:
         upbound.io/organization: ${UP_ORG}
         upbound.io/token: ${UP_ROBOT_TOKEN}
       authProvider: upbound
-      name: solution-idp-non-prod-frontend-frontend
+      # $$Server, $$Kind, $$Namespace, $$Name is supported
+      gitFilePathPattern: "state/solution-idp-non-prod/frontend/30-claims/$$Kind-$$Namespace-$$Name"
       skipMetricsLookup: true
       skipTLSVerify: true
       url: ${UP_CTP_URL}

--- a/plugins/backstage-plugin-scaffolder-backend-module-crossplane-utils/src/actions/crd-templating.ts
+++ b/plugins/backstage-plugin-scaffolder-backend-module-crossplane-utils/src/actions/crd-templating.ts
@@ -127,67 +127,63 @@ export function createCrdTemplateAction({config}: {config: any}) {
         };
         removeEmpty(filteredParameters);
       }
+
       const sourceInfo = {
         pushToGit: ctx.input.parameters.pushToGit,
         gitBranch: ctx.input.parameters.targetBranch || config.getOptionalString('kubernetesIngestor.crossplane.xrds.publishPhase.git.targetBranch'),
         gitRepo: ctx.input.parameters.repoUrl || config.getOptionalString('kubernetesIngestor.crossplane.xrds.publishPhase.git.repoUrl'),
-        gitLayout: ctx.input.parameters.manifestLayout,
-        basePath: ctx.input.parameters.manifestLayout === 'custom'
-          ? ctx.input.parameters.basePath
-          : ctx.input.parameters.manifestLayout === 'namespace-scoped'
-            ? `${ctx.input.parameters[ctx.input.namespaceParam || 'namespace']}`
-            : `${ctx.input.clusters[0]}/${ctx.input.parameters[ctx.input.namespaceParam || 'namespace']}/${ctx.input.kind}`
+        basePath: `${ctx.input.clusters[0]}/${ctx.input.parameters[ctx.input.namespaceParam || 'namespace']}/${ctx.input.kind}`
       }
-      let sourceFileUrl = '';
-      if (ctx.input.parameters.pushToGit && sourceInfo.gitRepo) {
+
+      const filePaths: string[] = [];
+      const kubernetesConfig = config.getOptionalConfig('kubernetes');
+      const clusterLocatorMethods = kubernetesConfig.getOptionalConfigArray('clusterLocatorMethods');
+      const clustersConfig = clusterLocatorMethods[0].getOptionalConfigArray('clusters');
+
+      ctx.input.clusters.forEach(cluster => {
+        const clusterConfig = clustersConfig.find((c: any) => c.getString('name') === cluster);
+        const gitRepoPath = clusterConfig.getOptionalString('gitFilePathPattern') || "state/$$Cluster/$$Kind-$$Namespace-$$Name";
+        const filePath = gitRepoPath
+          .replace('$$Cluster', cluster)
+          .replace('$$Kind', ctx.input.kind)
+          .replace('$$Namespace', ctx.input.parameters[ctx.input.namespaceParam || 'namespace'])
+          .replace('$$Name', ctx.input.parameters[ctx.input.nameParam]) + ".yaml";
+
+        const destFilepath = resolveSafeChildPath(ctx.workspacePath, filePath);
+
+        let sourceFileUrl = '';
         const gitUrl = new URL("https://" + sourceInfo.gitRepo);
         const owner = gitUrl.searchParams.get('owner');
         const repo = gitUrl.searchParams.get('repo');
         if (owner && repo) {
-          sourceFileUrl = `https://${gitUrl.host}/${owner}/${repo}/blob/${sourceInfo.gitBranch}/${sourceInfo.basePath}/${ctx.input.parameters[ctx.input.nameParam]}.yaml`;
+          sourceFileUrl = `https://${gitUrl.host}/${owner}/${repo}/blob/${sourceInfo.gitBranch}/${filePath}`;
         }
-      }
-      // Template the Kubernetes resource manifest
-      const manifest = {
-        apiVersion: ctx.input.apiVersion,
-        kind: ctx.input.kind,
-        metadata: {
-          name: ctx.input.parameters[ctx.input.nameParam],
-          ...(ctx.input.namespaceParam && {
-            namespace: ctx.input.parameters[ctx.input.namespaceParam],
-          }),
-          annotations: {
-            'upbound.backstage.io/source-info': JSON.stringify(sourceInfo),
-            'upbound.backstage.io/add-to-catalog': "true",
-            'upbound.backstage.io/owner': ctx.input.parameters[ctx.input.ownerParam],
-            'upbound.backstage.io/system': ctx.input.parameters[ctx.input.namespaceParam || 'namespace'],
-            ...(sourceFileUrl && { 'upbound.backstage.io/source-file-url': sourceFileUrl }),
+
+        const manifestYaml = yaml.dump({
+          apiVersion: ctx.input.apiVersion,
+          kind: ctx.input.kind,
+          metadata: {
+            annotations: {
+              'upbound.backstage.io/source-info': JSON.stringify(sourceInfo),
+              'upbound.backstage.io/add-to-catalog': "true",
+              'upbound.backstage.io/owner': ctx.input.parameters[ctx.input.ownerParam],
+              'upbound.backstage.io/system': ctx.input.parameters[ctx.input.namespaceParam || 'namespace'],
+              ...(sourceFileUrl && { 'upbound.backstage.io/source-file-url': sourceFileUrl }),
+            },
+            name: ctx.input.parameters[ctx.input.nameParam],
+            namespace: ctx.input.parameters[ctx.input.namespaceParam || 'namespace'],
           },
-        },
-        spec: filteredParameters,
-      };
+          spec: filteredParameters,
+        });
 
-      // Convert manifest to YAML
-      const manifestYaml = yaml.dump(manifest);
-
-      // Handle cluster-specific paths or default path
-      const filePaths: string[] = [];
-      ctx.input.clusters.forEach(cluster => {
-        const filePath = path.join(
-          cluster,
-          ctx.input.parameters[ctx.input.namespaceParam || 'namespace'],
-          ctx.input.kind,
-          `${ctx.input.parameters[ctx.input.nameParam]}.yaml`
-        );
-        const destFilepath = resolveSafeChildPath(ctx.workspacePath, filePath);
         fs.outputFileSync(destFilepath, manifestYaml);
         ctx.logger.info(`Manifest written to ${destFilepath}`);
         filePaths.push(destFilepath);
-      });
 
-      // Output the manifest and file paths
-      ctx.output('manifest', manifestYaml);
-      ctx.output('filePaths', filePaths);
+        // Output the manifest and file paths
+        ctx.output('manifest', manifestYaml);
+        ctx.output('filePaths', filePaths);
+      });
     },
   });
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
- remove cluster-scope as inputs
- remove namespace-scope as inputs
- remove custom as inputs
- adding a gitFilePathPattern per cluster with replaceable placeholders like

```
kubernetes:
  auth:
    providers:
      upbound: {}
  clusterLocatorMethods:
  - clusters:
    - name: solution-idp-non-prod-frontend-frontend
      authMetadata:
        upbound.io/organization: ${UP_ORG}
        upbound.io/token: ${UP_ROBOT_TOKEN}
      authProvider: upbound
      # $$Server, $$Kind, $$Namespace, $$Name is supported
      gitFilePathPattern: "state/solution-idp-non-prod/frontend/30-claims/$$Kind-$$Namespace-$$Name"
      skipMetricsLookup: true
      skipTLSVerify: true
      url: ${UP_CTP_URL}
    type: config
```

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
https://github.com/upbound/solution-idp/pull/29
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
